### PR TITLE
Rozszerzenie template’u pracy agentowej

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,13 @@
-FORGEJO_BASE_URL=https://forgejo.eengine.pl
-FORGEJO_OWNER=eengineSH
-FORGEJO_REPO=ai-coding-template
-FORGEJO_TOKEN=wklej_tutaj_token_api
-
+# GitHub API
 GITHUB_BASE_URL=https://api.github.com
-GITHUB_OWNER=eengineSH
-GITHUB_REPO=ai-coding-template
-GITHUB_TOKEN=wklej_tutaj_token_api
+GITHUB_OWNER=your-org-or-user
+GITHUB_REPO=your-repository
+GITHUB_TOKEN=replace_with_github_token
+
+# Forgejo API (opcjonalnie)
+FORGEJO_BASE_URL=https://forgejo.example.com
+FORGEJO_OWNER=your-org-or-user
+FORGEJO_REPO=your-repository
+FORGEJO_TOKEN=replace_with_forgejo_token
+
+# W typowym projekcie zostaw tylko zmienne dla hostingu, ktorego uzywasz.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Przykład:
+# * @OWNER/team-name

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+## Zasady
+
+1. Zaczynaj od issue albo specyfikacji, jeśli zmiana jest większa niż drobna poprawka.
+2. Pracuj na osobnym branchu.
+3. Otwieraj Pull Request do głównego brancha projektu.
+4. Opisz zakres, weryfikację i ryzyka.
+5. Nie dodawaj sekretów ani danych produkcyjnych.

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,25 @@
+name: Pomysł
+description: Zaproponuj pomysł do dyskusji.
+title: "[Idea]: "
+labels: []
+body:
+  - type: textarea
+    id: idea
+    attributes:
+      label: Pomysł
+      description: Co proponujesz?
+    validations:
+      required: true
+  - type: textarea
+    id: value
+    attributes:
+      label: Wartość
+      description: Jaki problem to rozwiązuje?
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Dodatkowe informacje
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,49 @@
+name: Bug
+description: Zgłoś błąd wymagający naprawy.
+title: "[Bug]: "
+labels: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Opis
+      description: Co nie działa i jaki jest faktyczny efekt?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Kroki odtworzenia
+      description: Podaj minimalne kroki prowadzące do błędu.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Oczekiwany wynik
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Faktyczny wynik
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Środowisko
+      description: Wersja aplikacji, branch, commit, przeglądarka, system lub inne istotne dane.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logi i komunikaty błędów
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Pytanie lub dyskusja
+    url: https://github.com/OWNER/REPOSITORY/discussions
+    about: Użyj dyskusji, jeśli temat nie jest jeszcze konkretnym bugiem, featurem ani taskiem.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature
+description: Zaproponuj nową funkcjonalność albo istotne rozszerzenie.
+title: "[Feature]: "
+labels: []
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Cel
+      description: Jaki problem użytkownika lub projektu rozwiązuje zmiana?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Zakres
+      description: Co powinno zostać zrobione?
+    validations:
+      required: true
+  - type: textarea
+    id: use_cases
+    attributes:
+      label: Przypadki użycia
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Kryteria akceptacji
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Dodatkowe informacje
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,33 @@
+name: Task
+description: Zgłoś zadanie techniczne, dokumentacyjne albo operacyjne.
+title: "[Task]: "
+labels: []
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Kontekst
+      description: Dlaczego to zadanie jest potrzebne?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Zakres prac
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Warunek ukończenia
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Ryzyka lub zależności
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+# Cel
+
+Krótko opisz, co zmienia ten PR i dlaczego.
+
+## Zakres
+
+1. 
+2. 
+
+## Specyfikacja lub issue
+
+- 
+
+## Weryfikacja
+
+1. 
+2. 
+
+## Ryzyka i rollback
+
+1. 
+2. 
+
+## Checklist
+
+- [ ] Zmiana jest zgodna z zakresem issue lub specyfikacji.
+- [ ] Uruchomiono dostępne testy albo opisano, dlaczego nie zostały uruchomione.
+- [ ] Zaktualizowano dokumentację, jeśli było to potrzebne.
+- [ ] Nie dodano sekretów, danych produkcyjnych ani zbędnych artefaktów.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Zgłaszanie podatności
+
+Nie publikuj szczegółów podatności jako publiczne issue, jeśli mogłoby to ułatwić wykorzystanie błędu.
+
+## Kontakt
+
+Uzupełnij preferowaną ścieżkę kontaktu dla zgłoszeń bezpieczeństwa.
+
+## Zakres
+
+Uzupełnij wspierane wersje albo branche projektu.

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,14 @@
+# Support
+
+## Gdzie szukać pomocy
+
+1. Dokumentacja projektu.
+2. Issues, jeśli temat jest konkretnym błędem albo zadaniem.
+3. Discussions, jeśli temat jest pytaniem lub propozycją.
+
+## Dane potrzebne do diagnozy
+
+1. Wersja albo commit.
+2. Środowisko.
+3. Kroki odtworzenia.
+4. Logi bez sekretów.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,31 @@
+# Instrukcje dla GitHub Copilot
+
+Obowiązują w tym repozytorium przy generowaniu kodu, komentarzy i code review.
+
+## Język
+
+- Komunikacja projektowa jest po polsku.
+- Komentarze review pisz jasno i konkretnie.
+
+## Priorytety review
+
+1. Błędy funkcjonalne i regresje.
+2. Ryzyka bezpieczeństwa.
+3. Brakujące testy lub weryfikacja.
+4. Niezgodność z istniejącymi wzorcami projektu.
+5. Nadmierna złożoność lub zmiany poza zakresem.
+
+## Zasady oceny
+
+- Nie zgłaszaj uwag kosmetycznych, jeśli nie wpływają na czytelność, utrzymanie albo działanie.
+- Każda uwaga powinna wskazywać konkretny problem i praktyczny sposób naprawy.
+- Gdy problem dotyczy testów, wskaż jaki scenariusz powinien zostać sprawdzony.
+- Gdy sugerujesz zmianę architektury, wyjaśnij trade-off.
+- Nie proponuj przepisywania większych fragmentów bez jasnego powodu.
+
+## Dokumentacja
+
+- `AGENTS.md` zawiera zasady dla agentów.
+- `README.md` jest dla człowieka.
+- `docs/specs/` zawiera specyfikacje zmian.
+- `docs/runbooks/` zawiera powtarzalne procedury operacyjne.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -1,0 +1,19 @@
+---
+applyTo: "**"
+---
+
+# Code Review
+
+Podczas review najpierw szukaj błędów, regresji, luk w testach i ryzyk bezpieczeństwa.
+
+## Format uwag
+
+1. Opisz problem.
+2. Wyjaśnij wpływ.
+3. Zaproponuj konkretną poprawkę.
+
+## Nie zgłaszaj
+
+1. Preferencji stylistycznych bez wpływu na utrzymanie.
+2. Refaktorów poza zakresem PR.
+3. Sugestii, które ignorują istniejące wzorce repozytorium.

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 .env
+.env.local
+.env.*.local
+.DS_Store
+tmp/
+logs/
+*.log
+*.tmp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Ten plik definiuje podstawowe zasady dla agentów (AI i automatyzacji) pracując
 
 ## Dokumentacja
 
+- Przy starcie nowego kontekstu najpierw sprawdź `docs/followups.md`, jeśli plik istnieje.
 - Dla agenta źródłem prawdy są pliki `AGENTS.md`.
 - Informacje dla agentów zapisuj w `AGENTS.md` najbliższym zakresowi danej funkcji/obszaru; globalny `AGENTS.md` traktuj jako miejsce na zasady przekrojowe, gdy nie ma bardziej adekwatnego pliku.
 - Szczegóły techniczne integracji (np. API, tokeny, workflow agenta) zapisuj w `docs/`.
@@ -28,9 +29,13 @@ Ten plik definiuje podstawowe zasady dla agentów (AI i automatyzacji) pracując
 - Dokumentacji integracji API szukaj w `docs/apis/`, a ich indeks i zasady w `docs/apis/AGENTS.md`.
 - Specyfikacji funkcjonalności szukaj w `docs/specs/`, a ich indeks i zasady w `docs/specs/AGENTS.md`.
 - Runbooków operacyjnych szukaj w `docs/runbooks/`, a ich indeks i zasady w `docs/runbooks/AGENTS.md`.
+- Skille agenta, jeśli projekt zdecyduje się ich używać, opisuj w `docs/skills/`.
 - Nazwy plików instrukcji zapisuj dokładnie jako `AGENTS.md` (wielkie `AGENTS`, małe `.md`).
 - W plikach `AGENTS.md` nie twórz odniesień do plików `README.md`.
 - W każdym folderze projektu powinien istnieć plik `README.md` opisujący zawartość folderu oraz informacje o podkatalogach.
+- Pliki `AGENTS.md` są przeznaczone dla agentów i automatyzacji.
+- Pliki `README.md` są przeznaczone dla człowieka.
+- Nie duplikuj semantycznie tych samych zasad w `AGENTS.md` i `README.md`; jeśli trzeba coś doprecyzować, ujednolić istniejący wpis zamiast dopisywać równoległy.
 - Dodawaj krótkie komentarze tylko tam, gdzie logika nie jest oczywista.
 
 ## Komunikacja zmian
@@ -70,11 +75,12 @@ Ten plik definiuje podstawowe zasady dla agentów (AI i automatyzacji) pracując
 
 ### Repozytorium i narzędzia
 
-- Główne repozytorium (origin): `https://github.com/eengineSH/ai-coding-template`.
-- Oprogramowanie hostujące (origin): `GitHub`.
+- Główne repozytorium ustalaj z `git remote -v`.
+- Oprogramowanie hostujące rozpoznawaj po `origin` albo po wskazaniu człowieka.
 - Operacje na issues wykonujemy przez API:
   - GitHub (domyślnie): `scripts/github-issues.sh`
   - Forgejo (gdy dotyczy repo na Forgejo): `scripts/forgejo-issues.sh`
+- Sekrety i tokeny ładuj przez helper `scripts/load_env.sh` albo przez jawnie wskazane zmienne środowiskowe; nie wypisuj tokenów na stdout.
 
 ### Skróty poleceń
 
@@ -94,9 +100,9 @@ Ten plik definiuje podstawowe zasady dla agentów (AI i automatyzacji) pracując
 
 ### Specyfikacje a issue
 
-- Jeśli zadanie ma issue na Forgejo i wymaga specyfikacji, to specyfikacja ma powstać jako komentarz do danego issue (nie w `docs/specs/`).
-- Jeśli specyfikacja jest w komentarzu i prosisz o jej poprawę, edytuję istniejący komentarz (nie dodaję nowego).
-- Jeśli nie ma issue, a potrzebna jest specyfikacja, to najpierw pytam gdzie ją umieścić (issue vs `docs/specs/`) i czy wcześniej nie założyć pod to nowego issue.
+- Jeśli zadanie ma issue i wymaga specyfikacji, dopasuj miejsce specyfikacji do zasad projektu.
+- Gdy projekt nie ma własnej decyzji, domyślnym miejscem roboczym jest `docs/specs/`.
+- Specyfikacja nie oznacza automatycznej zgody na implementację, jeśli człowiek nie poprosił wprost o realizację.
 
 ### Issue (tworzenie i triage)
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,43 @@
-# ai-coding-template
+# AI Coding Template
 
-Minimalne repozytorium startowe do eksperymentów i szybkiego prototypowania.
+Repozytorium startowe dla projektów, w których człowiek i agenci AI mają pracować w przewidywalny sposób.
 
 ## Zawartość
 
-- `README.md` - podstawowy opis projektu.
 - `AGENTS.md` - zasady pracy dla agentów i automatyzacji.
+- `.github/` - szablony GitHuba, Pull Requestów, issue, instrukcje Copilota i pliki community health.
+- `docs/` - dokumentacja operacyjna i techniczna projektu.
+- `docs/apis/` - dokumentacja integracji API.
+- `docs/specs/` - specyfikacje zmian i funkcjonalności.
+- `docs/runbooks/` - syntetyczne procedury operacyjne.
+- `docs/skills/` - puste miejsce na przyszłe skille agenta.
+- `scripts/` - helpery do pracy z API i środowiskiem.
 
 ## Szybki start
 
-1. Dodaj pliki źródłowe projektu.
-2. Uzupełnij sekcję "Uruchomienie" o konkretne komendy.
-3. Dodaj testy i skonfiguruj CI, jeśli projekt będzie rozwijany.
+1. Sklonuj repozytorium albo użyj go jako template’u.
+2. Podmień nazwę projektu, ownera i repozytorium w plikach konfiguracyjnych oraz dokumentacji.
+3. Zdecyduj, czy projekt używa GitHub, Forgejo czy obu integracji.
+4. Uzupełnij `.env.example` o właściwe zmienne dla projektu.
+5. Usuń integracje, których projekt nie będzie używał.
+6. Dopisz pierwszą specyfikację w `docs/specs/` albo podlinkuj issue, jeśli praca startuje z issue.
+7. Uzupełnij sekcję "Uruchomienie" o konkretne komendy projektu.
+8. Dodaj testy i CI, jeśli projekt będzie rozwijany długoterminowo.
+
+## Adaptacja do projektu
+
+1. `AGENTS.md`
+   - zostaw tylko zasady, które mają obowiązywać w danym projekcie
+   - przenieś lokalne zasady do najbliższego folderu, którego dotyczą
+2. `.github/`
+   - dopasuj szablony issue, PR i instrukcje Copilota do technologii projektu
+   - usuń sekcje, które nie mają zastosowania
+3. `docs/specs/`
+   - trzymaj kompletne specyfikacje zmian, jeśli projekt wymaga specyfikowania przed kodowaniem
+4. `docs/runbooks/`
+   - dopisuj tylko powtarzalne procedury, które naprawdę będą używane
+5. `docs/skills/`
+   - zostaw puste, dopóki projekt nie potrzebuje własnych skilli agenta
 
 ## Uruchomienie
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -12,16 +12,28 @@ Ten plik opisuje zawartość katalogu `docs/` i wskazuje, gdzie szukać informac
 - `docs/AGENTS.md`
   - Indeks dokumentacji technicznej w `docs/`.
   - Opisuje co, gdzie i po co znajduje się w tym katalogu.
+- `docs/followups.md`
+  - Rejestr cyklicznych lub odłożonych kontroli operacyjnych.
+- `docs/system-map.md`
+  - Mapa systemu, komponentów i środowisk.
+- `docs/integrations.md`
+  - Indeks integracji zewnętrznych.
+- `docs/cron.md`
+  - Mapa zadań cyklicznych, jeśli projekt ich używa.
 - `docs/apis/AGENTS.md`
   - Indeks dokumentacji integracji API.
   - Zawiera mapę plików API i zasady prowadzenia dokumentacji API.
   - Obejmuje dokumentację `Forgejo-API.md` i `GitHub-API.md`.
+- `docs/optimizations/AGENTS.md`
+  - Indeks dokumentacji optymalizacyjnej, jeśli projekt jej potrzebuje.
 - `docs/specs/AGENTS.md`
   - Indeks specyfikacji funkcjonalności przygotowywanych do implementacji.
   - Zawiera mapę plików specyfikacji i zasady ich tworzenia.
 - `docs/runbooks/AGENTS.md`
   - Indeks runbooków operacyjnych.
   - Zawiera mapę plików runbooków i zasady ich tworzenia.
+- `docs/skills/AGENTS.md`
+  - Opis miejsca na przyszłe skille agenta.
 
 ## Zasady aktualizacji
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,19 @@ Ten folder zawiera uporządkowaną dokumentację i wiedzę o repozytorium.
 
 - `apis/`
   - dokumentacja integracji API (konfiguracja, endpointy, operacje)
+- `followups.md`
+  - rejestr cyklicznych lub odłożonych kontroli
+- `system-map.md`
+  - mapa komponentów, środowisk i zależności projektu
+- `integrations.md`
+  - indeks integracji zewnętrznych
+- `cron.md`
+  - mapa zadań cyklicznych, jeśli projekt ich używa
 - `specs/`
   - specyfikacje zmian (gdy nie są prowadzone jako komentarz do issue na Forgejo)
 - `runbooks/`
   - instrukcje operacyjne dla agenta (jak wykonywać powtarzalne czynności)
+- `skills/`
+  - miejsce na przyszłe skille agenta AI
+- `optimizations/`
+  - miejsce na notatki i runbooki dotyczące optymalizacji

--- a/docs/apis/Forgejo-API.md
+++ b/docs/apis/Forgejo-API.md
@@ -23,8 +23,8 @@ Jak pobrać token API w Forgejo:
 
 - Token przekazujemy przez nagłówek:
   - `Authorization: token <FORGEJO_TOKEN>`
-- Bazowy URL API:
-  - `https://git.iphoenix.pl/api/v1`
+- Bazowy URL API wynika z `FORGEJO_BASE_URL`, np.:
+  - `https://forgejo.example.com/api/v1`
 
 ## Konfiguracja lokalna
 
@@ -32,7 +32,7 @@ Jak pobrać token API w Forgejo:
    - `cp .env.example .env`
 2. Uzupełnij token w `FORGEJO_TOKEN`.
 3. Załaduj zmienne środowiskowe:
-   - `set -a; source .env; set +a`
+   - `source scripts/load_env.sh .env`
 
 Uwagi:
 

--- a/docs/apis/GitHub-API.md
+++ b/docs/apis/GitHub-API.md
@@ -38,7 +38,7 @@ Jak pobrać token API w GitHub:
    - `GITHUB_REPO`
    - `GITHUB_TOKEN`
 3. Załaduj zmienne środowiskowe:
-   - `set -a; source .env; set +a`
+   - `source scripts/load_env.sh .env`
 
 Uwagi:
 
@@ -86,10 +86,11 @@ Uwagi praktyczne:
 - Nie commitujemy `.env` ani tokenów.
 - Token musi mieć uprawnienia do odczytu i zapisu issues w repo docelowym.
 
-## Wyniki testów
+## Test kontrolny
 
-- Data testu: `2026-02-11`
-- Zakres testu: `whoami`, `issue-create`, `issue-get`, `issue-comment`, `issue-close`, `issue-open`, `issues-list`.
-- Repo testowe: `eengineSH/ai-coding-template`
-- Wynik dla konfiguracji z `.env`: `PASS`
-- Utworzone i domknięte testowe issue: `#1`
+Po uzupełnieniu konfiguracji wykonaj:
+
+1. `scripts/github-issues.sh whoami`
+2. `scripts/github-issues.sh issues-list open`
+
+Operacje zapisu na realnym repo wykonuj dopiero po świadomej decyzji człowieka albo zgodnie z zasadami projektu.

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -1,0 +1,15 @@
+# Cron i zadania cykliczne
+
+Ten plik jest miejscem na mapę zadań cyklicznych projektu.
+
+## Zadania
+
+| Nazwa | Harmonogram | Komenda | Środowisko | Uwagi |
+| --- | --- | --- | --- | --- |
+| do uzupełnienia | do uzupełnienia | do uzupełnienia | do uzupełnienia | - |
+
+## Zasady dokumentowania
+
+1. Zapisuj pełną komendę lub entrypoint.
+2. Podawaj środowisko, na którym zadanie działa.
+3. Dopisuj logi, locki i warunki alarmowe, jeśli istnieją.

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1,0 +1,62 @@
+# Follow-ups
+
+Ten plik jest operacyjnym rejestrem cyklicznych lub odłożonych kontroli.
+
+## Statusy
+
+- `OK` - zadanie wykonane poprawnie.
+- `WARN` - zadanie wykonane, ale wykryto odchylenie.
+- `FAIL` - zadanie wykonane i wykryto błąd wymagający reakcji.
+- `PENDING` - brak pierwszego uruchomienia.
+
+## Rejestr zadań
+
+| ID zadania | Priorytet | Częstotliwość | Ostatnie uruchomienie | Ostatni status | Następny deadline |
+| --- | --- | --- | --- | --- | --- |
+| EXAMPLE_TASK | Standard | co tydzień | - | PENDING | - |
+
+## Szablon nowego zadania
+
+Każde kolejne zadanie dodawaj jako osobną sekcję:
+
+1. `### TASK_ID`
+2. Metadane zadania:
+   a) opis
+   b) harmonogram
+   c) zakres
+   d) kryteria kontroli
+   e) reguła alarmowa
+3. Checklista kontrolna.
+4. Historia uruchomień.
+5. Pełny wynik ostatniego uruchomienia.
+
+### EXAMPLE_TASK
+
+- Opis:
+  - przykładowa kontrola do zastąpienia pierwszym realnym zadaniem projektu.
+- Harmonogram:
+  - co tydzień.
+- Zakres:
+  - do ustalenia przez projekt.
+- Kryteria kontroli:
+  - wynik jest kompletny.
+  - wynik jest możliwy do zweryfikowania.
+- Reguła alarmowa:
+  - przy statusie `FAIL` zgłoś problem w domyślnym trackerze projektu.
+
+#### Checklista kontrolna
+
+1. Ustal zakres kontroli.
+2. Wykonaj kontrolę.
+3. Zapisz wynik w historii.
+4. Zaktualizuj rejestr zadań.
+
+#### Historia uruchomień
+
+| Data uruchomienia | Status | Szczegóły | Akcja |
+| --- | --- | --- | --- |
+| - | PENDING | Brak uruchomienia | Uzupełnić po pierwszej kontroli |
+
+#### Pełny wynik ostatniego uruchomienia
+
+- Brak.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,16 @@
+# Integracje
+
+Ten plik jest indeksem integracji zewnętrznych używanych przez projekt.
+
+## Lista integracji
+
+| Nazwa | Typ | Środowiska | Dokumentacja | Uwagi |
+| --- | --- | --- | --- | --- |
+| GitHub | API | development | `docs/apis/GitHub-API.md` | opcjonalnie |
+| Forgejo | API | development | `docs/apis/Forgejo-API.md` | opcjonalnie |
+
+## Zasady
+
+1. Każda integracja powinna mieć właściciela albo miejsce odpowiedzialności.
+2. Dane dostępowe nie trafiają do repozytorium.
+3. Szczegóły endpointów i autoryzacji zapisuj w `docs/apis/`.

--- a/docs/optimizations/AGENTS.md
+++ b/docs/optimizations/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS - docs/optimizations
+
+Ten katalog jest miejscem na dokumentację optymalizacji.
+
+## Cel katalogu
+
+- Opisywać analizy wydajnościowe.
+- Przechowywać decyzje dotyczące zmian konfiguracji, zapytań, indeksów albo architektury.
+- Oddzielać pomysły od zatwierdzonych działań.
+
+## Mapa plików
+
+- `docs/optimizations/AGENTS.md`
+  - Zasady dla agentów dotyczące optymalizacji.
+- `docs/optimizations/README.md`
+  - Opis katalogu dla człowieka.
+- `docs/optimizations/szablon-optymalizacji.md`
+  - Szablon notatki optymalizacyjnej.
+- `docs/optimizations/pomysly.md`
+  - Miejsce na pomysły przed triage.
+
+## Zasady
+
+- Każda propozycja optymalizacji powinna zawierać stan obecny, proponowaną zmianę, sposób weryfikacji i rollback.
+- Nie zapisuj w repo wrażliwych danych produkcyjnych ani pełnych dumpów logów.

--- a/docs/optimizations/README.md
+++ b/docs/optimizations/README.md
@@ -1,0 +1,9 @@
+# optimizations
+
+Katalog zawiera dokumentację dotyczącą optymalizacji.
+
+## Zawartość
+
+- `AGENTS.md` - zasady dla agentów.
+- `szablon-optymalizacji.md` - wzór notatki optymalizacyjnej.
+- `pomysly.md` - lista pomysłów do późniejszego triage.

--- a/docs/optimizations/pomysly.md
+++ b/docs/optimizations/pomysly.md
@@ -1,0 +1,9 @@
+# Pomysły optymalizacyjne
+
+Ten plik służy do zapisywania pomysłów przed decyzją, czy powstanie pełna notatka albo issue.
+
+## Lista
+
+| Pomysł | Obszar | Potencjalny efekt | Status |
+| --- | --- | --- | --- |
+| do uzupełnienia | do uzupełnienia | do uzupełnienia | do triage |

--- a/docs/optimizations/szablon-optymalizacji.md
+++ b/docs/optimizations/szablon-optymalizacji.md
@@ -1,0 +1,29 @@
+# Optymalizacja: nazwa
+
+## Cel
+
+Co ma się poprawić i dlaczego.
+
+## Stan obecny
+
+1. Aktualne zachowanie.
+2. Dane pomiarowe.
+3. Ograniczenia.
+
+## Proponowana zmiana
+
+1. Co zmienić.
+2. Dlaczego ta zmiana powinna pomóc.
+3. Jakie są skutki uboczne.
+
+## Weryfikacja
+
+1. Metryki przed zmianą.
+2. Metryki po zmianie.
+3. Kryterium sukcesu.
+
+## Ryzyka i rollback
+
+1. Ryzyko.
+2. Sposób wykrycia.
+3. Sposób cofnięcia.

--- a/docs/runbooks/001-pr-review.md
+++ b/docs/runbooks/001-pr-review.md
@@ -1,0 +1,31 @@
+# Runbook: przegląd Pull Requesta
+
+## Cel
+
+Wykonać powtarzalny przegląd Pull Requesta bez pomijania kontekstu, ryzyk i weryfikacji.
+
+## Wymagania wejściowe
+
+1. Numer Pull Requesta albo link.
+2. Dostęp do repozytorium.
+3. Dostęp do metadanych PR, listy plików i diffu.
+
+## Kroki
+
+1. Pobierz metadane PR.
+2. Pobierz listę zmienionych plików.
+3. Przeczytaj opis PR i powiązane issue lub specyfikację.
+4. Sprawdź diff pod kątem:
+   a) regresji funkcjonalnych
+   b) błędów bezpieczeństwa
+   c) brakujących testów
+   d) zmian poza zakresem
+5. Zweryfikuj lokalne wzorce w podobnym kodzie.
+6. Uruchom dostępne testy albo opisz, dlaczego nie zostały uruchomione.
+7. Zwróć wynik review z ustalonym priorytetem uwag.
+
+## Weryfikacja
+
+1. Każda uwaga wskazuje konkretny problem.
+2. Uwagi blokujące są jasno odróżnione od sugestii.
+3. Raport zawiera informację o testach.

--- a/docs/runbooks/002-smoke-test-po-zmianach.md
+++ b/docs/runbooks/002-smoke-test-po-zmianach.md
@@ -1,0 +1,28 @@
+# Runbook: smoke test po zmianach
+
+## Cel
+
+Szybko potwierdzić, że najważniejsze ścieżki projektu działają po zmianie.
+
+## Wymagania wejściowe
+
+1. Lista zmienionych obszarów.
+2. Dostęp do środowiska testowego albo lokalnego.
+3. Komendy uruchomienia aplikacji i testów.
+
+## Kroki
+
+1. Ustal commit, branch i zakres zmian.
+2. Uruchom aplikację w docelowym trybie testu.
+3. Sprawdź podstawową stronę lub główny entrypoint.
+4. Sprawdź ścieżkę bezpośrednio dotkniętą zmianą.
+5. Sprawdź jeden scenariusz błędu.
+6. Sprawdź logi aplikacji, konsolę albo monitoring, jeśli są dostępne.
+7. Zanotuj wynik i blokery.
+
+## Weryfikacja
+
+1. Aplikacja startuje.
+2. Główna ścieżka działa.
+3. Zmieniony obszar działa.
+4. Nie pojawiły się nowe błędy w dostępnych logach.

--- a/docs/runbooks/003-obsluga-issue-api.md
+++ b/docs/runbooks/003-obsluga-issue-api.md
@@ -1,0 +1,27 @@
+# Runbook: obsługa issue przez API
+
+## Cel
+
+Wykonywać operacje na issue przez API w sposób powtarzalny i audytowalny.
+
+## Wymagania wejściowe
+
+1. Hosting repozytorium.
+2. Owner i nazwa repozytorium.
+3. Token API z właściwymi uprawnieniami.
+4. Narzędzia `curl` i `jq`.
+
+## Kroki
+
+1. Ustal repozytorium z `git remote -v` albo z polecenia człowieka.
+2. Załaduj wymagane zmienne środowiskowe przez `scripts/load_env.sh` lub jawny mechanizm projektu.
+3. Odczytaj issue po numerze, jeśli zadanie dotyczy istniejącego issue.
+4. Dla nowego issue przygotuj czytelny opis w Markdown.
+5. Wykonaj operację przez właściwy skrypt lub endpoint API.
+6. Zweryfikuj wynik ponownym odczytem API.
+
+## Weryfikacja
+
+1. Operacja zakończyła się kodem HTTP 2xx.
+2. Issue ma oczekiwany tytuł, treść, stan i metadane.
+3. W odpowiedzi nie wypisano sekretów.

--- a/docs/runbooks/004-release-deploy-checklista.md
+++ b/docs/runbooks/004-release-deploy-checklista.md
@@ -1,0 +1,30 @@
+# Runbook: checklista release/deploy
+
+## Cel
+
+Utrzymać przewidywalny przebieg wydania albo wdrożenia.
+
+## Wymagania wejściowe
+
+1. Branch albo commit do wydania.
+2. Lista zmian.
+3. Dostęp do środowiska testowego.
+4. Decyzja człowieka o wdrożeniu, jeśli projekt jej wymaga.
+
+## Kroki
+
+1. Potwierdź czysty stan working copy.
+2. Potwierdź branch i commit.
+3. Sprawdź, czy są migracje albo zmiany konfiguracji.
+4. Uruchom testy automatyczne.
+5. Wykonaj smoke test.
+6. Przygotuj krótki opis zmian.
+7. Wykonaj wdrożenie zgodnie z procedurą projektu.
+8. Po wdrożeniu sprawdź kluczowe ścieżki i logi.
+
+## Weryfikacja
+
+1. Wdrożony commit jest zgodny z testowanym commitem.
+2. Testy i smoke test przeszły.
+3. Nie ma nowych błędów w monitoringu albo logach.
+4. Istnieje plan rollbacku.

--- a/docs/runbooks/005-diagnostyka-ci.md
+++ b/docs/runbooks/005-diagnostyka-ci.md
@@ -1,0 +1,27 @@
+# Runbook: diagnostyka CI
+
+## Cel
+
+Szybko ustalić przyczynę błędów CI i odróżnić problem kodu od problemu środowiska.
+
+## Wymagania wejściowe
+
+1. Link do runu CI albo nazwa workflow.
+2. Commit lub branch.
+3. Dostęp do logów CI.
+
+## Kroki
+
+1. Ustal, który job i który krok zakończył się błędem.
+2. Pobierz pełny log błędnego kroku.
+3. Sprawdź, czy błąd jest deterministyczny.
+4. Porównaj z ostatnim zielonym runem, jeśli jest dostępny.
+5. Odtwórz błąd lokalnie, gdy to możliwe.
+6. Jeśli błąd wynika z kodu, przygotuj poprawkę.
+7. Jeśli błąd wynika ze środowiska, opisz zależność i sposób weryfikacji.
+
+## Weryfikacja
+
+1. Przyczyna błędu jest wskazana konkretnie.
+2. Poprawka albo rekomendacja ma jasny zakres.
+3. Po zmianie CI przechodzi albo wiadomo, co nadal blokuje.

--- a/docs/runbooks/AGENTS.md
+++ b/docs/runbooks/AGENTS.md
@@ -12,6 +12,16 @@ Ten plik jest mapą instrukcji operacyjnych (runbooków) dla agenta.
 
 - `docs/runbooks/AGENTS.md`
   - Indeks i zasady tworzenia runbooków.
+- `docs/runbooks/001-pr-review.md`
+  - Ogólna procedura przeglądu Pull Requesta.
+- `docs/runbooks/002-smoke-test-po-zmianach.md`
+  - Ogólna procedura smoke testu po zmianach.
+- `docs/runbooks/003-obsluga-issue-api.md`
+  - Ogólna procedura obsługi issue przez API.
+- `docs/runbooks/004-release-deploy-checklista.md`
+  - Ogólna checklista release/deploy.
+- `docs/runbooks/005-diagnostyka-ci.md`
+  - Ogólna procedura diagnostyki błędów CI.
 - `docs/runbooks/*.md`
   - Poszczególne runbooki (jeden plik na jeden proces/obszar).
 
@@ -19,6 +29,7 @@ Ten plik jest mapą instrukcji operacyjnych (runbooków) dla agenta.
 
 - Twórz jeden runbook na jedną procedurę.
 - Stosuj nazwy opisowe, np. `obsluga-issue.md`, `przygotowanie-pr.md`.
+- Runbooki w tym template są celowo syntetyczne i nie zawierają założeń konkretnego projektu.
 - Każdy runbook powinien zawierać:
   - cel i zakres procedury,
   - wymagania wejściowe (uprawnienia, tokeny, narzędzia),

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -5,6 +5,11 @@ Katalog zawiera runbooki, czyli powtarzalne instrukcje operacyjne dla agenta.
 ## Zawartość
 
 - `AGENTS.md` - zasady tworzenia i mapa runbooków.
+- `001-pr-review.md` - ogólny przegląd Pull Requesta.
+- `002-smoke-test-po-zmianach.md` - ogólny smoke test po zmianach.
+- `003-obsluga-issue-api.md` - ogólna obsługa issue przez API.
+- `004-release-deploy-checklista.md` - ogólna checklista release/deploy.
+- `005-diagnostyka-ci.md` - ogólna diagnostyka CI.
 - `*.md` - runbooki dla konkretnych procesów.
 
 ## Jak używać

--- a/docs/skills/AGENTS.md
+++ b/docs/skills/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS - docs/skills
+
+Ten katalog jest miejscem na przyszłe skille agenta AI.
+
+## Cel katalogu
+
+- Przechowywanie projektowych skilli, jeśli projekt będzie ich potrzebował.
+- Oddzielenie powtarzalnych workflow agenta od ogólnych zasad w `AGENTS.md`.
+- Unikanie narzucania gotowych skilli w samym template.
+
+## Zasady
+
+- Nie dodawaj skilla, dopóki projekt nie ma realnego, powtarzalnego procesu.
+- Każdy skill trzymaj w osobnym podkatalogu z plikiem `SKILL.md`.
+- Jeśli skill ma skrypty, trzymaj je w podkatalogu `scripts/` danego skilla.
+- Jeśli skill ma przykłady lub szablony, trzymaj je w podkatalogu `assets/` danego skilla.

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -1,0 +1,13 @@
+# skills
+
+Katalog jest pustym miejscem na przyszłe skille agenta AI.
+
+## Zawartość
+
+- `AGENTS.md` - zasady dla agentów dotyczące tego katalogu.
+
+## Kiedy dodawać skill
+
+1. Gdy proces jest powtarzalny.
+2. Gdy zwykły runbook nie wystarcza.
+3. Gdy warto dołączyć skrypty, szablony albo referencje.

--- a/docs/specs/AGENTS.md
+++ b/docs/specs/AGENTS.md
@@ -12,18 +12,23 @@ Ten plik jest mapą specyfikacji AI dla funkcjonalności projektu.
 
 - `docs/specs/AGENTS.md`
   - Indeks i zasady tworzenia specyfikacji.
+- `docs/specs/_template.md`
+  - Bazowy szablon specyfikacji end-to-end.
 - `docs/specs/*.md`
   - Właściwe specyfikacje funkcjonalności (po jednym pliku na funkcjonalność).
 
 ## Zasady tworzenia specyfikacji
 
 - Twórz jeden plik specyfikacji na jedną funkcjonalność.
-- Stosuj nazwy opisowe, np. `logowanie-uzytkownika.md`, `import-kontrahentow.md`.
+- Stosuj nazwy w schemacie `NNN-nazwa.md`, np. `001-logowanie-uzytkownika.md`.
+- Specyfikacja powinna być kompletna end-to-end i gotowa do implementacji bez zostawiania otwartych decyzji.
 - Każda specyfikacja powinna zawierać co najmniej:
   - cel biznesowy i zakres,
   - wymagania funkcjonalne,
+  - przypadki użycia,
   - przypadki brzegowe,
+  - wpływ na istniejące elementy systemu,
   - kryteria akceptacji,
-  - wpływ na istniejące elementy systemu.
+  - plan walidacji.
 - Jeśli specyfikacja zastępuje starszą wersję, dodaj sekcję "Historia zmian".
 - Po dodaniu nowego pliku dopisz go do sekcji "Mapa plików" w tym dokumencie.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -5,10 +5,11 @@ Katalog zawiera specyfikacje funkcjonalności przygotowywane pod implementację.
 ## Zawartość
 
 - `AGENTS.md` - zasady tworzenia i mapa plików specyfikacji.
+- `_template.md` - bazowy szablon specyfikacji.
 - `*.md` - specyfikacje funkcjonalności (po jednej funkcjonalności na plik).
 
 ## Jak używać
 
 1. Sprawdź zasady w `AGENTS.md`.
-2. Dodaj nową specyfikację jako osobny plik `*.md`.
+2. Skopiuj strukturę z `_template.md`.
 3. Uzupełnij mapę plików w `AGENTS.md`.

--- a/docs/specs/_template.md
+++ b/docs/specs/_template.md
@@ -1,0 +1,57 @@
+# Specyfikacja: nazwa zmiany
+
+## 1. Cel
+
+Opisz po co powstaje zmiana i jaki problem rozwiązuje.
+
+## 2. Zakres
+
+1. Co wchodzi w zakres.
+2. Co jest poza zakresem.
+
+## 3. Przypadki użycia
+
+1. Scenariusz podstawowy.
+2. Scenariusze alternatywne.
+3. Scenariusze błędów.
+
+## 4. Wymagania funkcjonalne
+
+1. Wymaganie pierwsze.
+2. Wymaganie drugie.
+
+## 5. Przypadki brzegowe
+
+1. Brak danych.
+2. Niepoprawne dane.
+3. Brak uprawnień.
+4. Błąd integracji zewnętrznej.
+
+## 6. Wpływ na system
+
+1. Kod aplikacji.
+2. Dane i migracje.
+3. Konfiguracja.
+4. Integracje.
+5. Dokumentacja.
+
+## 7. Kryteria akceptacji
+
+1. Kryterium pierwsze.
+2. Kryterium drugie.
+
+## 8. Plan walidacji
+
+1. Testy automatyczne.
+2. Testy ręczne.
+3. Kontrola logów lub monitoringu.
+
+## 9. Ryzyka i rollback
+
+1. Ryzyko.
+2. Sposób wykrycia.
+3. Sposób wycofania.
+
+## 10. Historia zmian
+
+- YYYY-MM-DD: utworzenie specyfikacji.

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -1,0 +1,23 @@
+# Mapa systemu
+
+Ten plik jest miejscem na mapę komponentów, środowisk i zależności projektu.
+
+## Środowiska
+
+| Nazwa | URL lub host | Przeznaczenie | Uwagi |
+| --- | --- | --- | --- |
+| local | do uzupełnienia | development | - |
+| test | do uzupełnienia | testy | - |
+| production | do uzupełnienia | produkcja | - |
+
+## Komponenty
+
+| Komponent | Rola | Technologia | Właściciel |
+| --- | --- | --- | --- |
+| app | aplikacja główna | do uzupełnienia | do uzupełnienia |
+
+## Zależności
+
+| Zależność | Typ | Do czego służy | Dokumentacja |
+| --- | --- | --- | --- |
+| do uzupełnienia | API/usługa/baza | do uzupełnienia | do uzupełnienia |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,8 +6,9 @@ Katalog zawiera skrypty pomocnicze do pracy z repozytorium i integracjami.
 
 - `forgejo-issues.sh` - operacje na issue przez API Forgejo (odczyt, tworzenie, komentarze, zmiana stanu).
 - `github-issues.sh` - operacje na issue przez API GitHub (odczyt, tworzenie, komentarze, zmiana stanu).
+- `load_env.sh` - bezpieczne ładowanie wybranych kluczy z `.env` bez wypisywania sekretów.
 
 ## Uruchamianie
 
-Skrypt uruchamiaj z poziomu repo po ustawieniu wymaganych zmiennych środowiskowych Forgejo.
+Skrypty uruchamiaj z poziomu repo po ustawieniu wymaganych zmiennych środowiskowych.
 Szczegóły konfiguracji są opisane w dokumentacji technicznej katalogu `docs/`.

--- a/scripts/forgejo-issues.sh
+++ b/scripts/forgejo-issues.sh
@@ -13,9 +13,9 @@ Uzycie:
   scripts/forgejo-issues.sh issue-close <nr>
 
 Wymagane zmienne srodowiskowe:
-  FORGEJO_BASE_URL  np. https://git.iphoenix.pl
-  FORGEJO_OWNER     np. fizol
-  FORGEJO_REPO      np. ai-coding-template
+  FORGEJO_BASE_URL  np. https://forgejo.example.com
+  FORGEJO_OWNER     np. your-org-or-user
+  FORGEJO_REPO      np. your-repository
   FORGEJO_TOKEN     token API Forgejo
 USAGE
   exit 0
@@ -32,6 +32,11 @@ done
 : "${FORGEJO_OWNER:?Brak FORGEJO_OWNER}"
 : "${FORGEJO_REPO:?Brak FORGEJO_REPO}"
 : "${FORGEJO_TOKEN:?Brak FORGEJO_TOKEN}"
+
+if [[ "${FORGEJO_TOKEN}" == wklej_* || "${FORGEJO_TOKEN}" == replace_with_* ]]; then
+  echo "FORGEJO_TOKEN wyglada na placeholder. Ustaw prawidlowy token API Forgejo w .env." >&2
+  exit 1
+fi
 
 BASE="${FORGEJO_BASE_URL%/}/api/v1"
 REPO_PATH="/repos/${FORGEJO_OWNER}/${FORGEJO_REPO}"

--- a/scripts/github-issues.sh
+++ b/scripts/github-issues.sh
@@ -14,8 +14,8 @@ Uzycie:
 
 Wymagane zmienne srodowiskowe:
   GITHUB_BASE_URL  np. https://api.github.com
-  GITHUB_OWNER     np. eEngineSoftwareHouse
-  GITHUB_REPO      np. ansible
+  GITHUB_OWNER     np. your-org-or-user
+  GITHUB_REPO      np. your-repository
   GITHUB_TOKEN     token API GitHub
 USAGE
   exit 0
@@ -33,7 +33,7 @@ done
 : "${GITHUB_REPO:?Brak GITHUB_REPO}"
 : "${GITHUB_TOKEN:?Brak GITHUB_TOKEN}"
 
-if [[ "${GITHUB_TOKEN}" == wklej_* ]]; then
+if [[ "${GITHUB_TOKEN}" == wklej_* || "${GITHUB_TOKEN}" == replace_with_* ]]; then
   echo "GITHUB_TOKEN wyglada na placeholder. Ustaw prawidlowy token API GitHub w .env." >&2
   exit 1
 fi

--- a/scripts/load_env.sh
+++ b/scripts/load_env.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+env_file="${1:-.env}"
+
+if [[ ! -f "$env_file" ]]; then
+  echo "Brak pliku env: $env_file" >&2
+  exit 1
+fi
+
+load_key() {
+  local key="$1"
+  local value
+
+  value="$(grep -E "^${key}=" "$env_file" | tail -n 1 | cut -d= -f2- || true)"
+  if [[ -n "$value" ]]; then
+    export "$key=$value"
+  fi
+}
+
+load_key GITHUB_BASE_URL
+load_key GITHUB_OWNER
+load_key GITHUB_REPO
+load_key GITHUB_TOKEN
+load_key FORGEJO_BASE_URL
+load_key FORGEJO_OWNER
+load_key FORGEJO_REPO
+load_key FORGEJO_TOKEN


### PR DESCRIPTION
## Cel

Rozszerzenie repozytorium szablonowego o komplet ogólnych praktyk pracy agentowej i pliki GitHuba.

## Zakres

1. Dodano szablony GitHuba: issue forms, PR template, community health, Dependabot i instrukcje Copilota.
2. Dodano `docs/followups.md`, szablon specyfikacji, syntetyczne runbooki oraz katalog `docs/skills/` bez gotowych skilli.
3. Dodano bazowe dokumenty `system-map`, `integrations`, `cron` i `optimizations`.
4. Uogólniono template przez usunięcie projektowych wartości z dokumentacji i przykładów.
5. Dodano `scripts/load_env.sh` oraz bezpieczniejsze placeholdery sekretów.

## Weryfikacja

1. `bash -n scripts/*.sh`
2. `scripts/github-issues.sh --help`
3. `scripts/forgejo-issues.sh --help`
4. `bash scripts/load_env.sh .env.example`
5. Parsowanie YAML plików `.github` przez Ruby `YAML.load_file`.

## Poza zakresem

1. Brak CI.
2. Brak rozbudowy skryptów issue o dodatkowe funkcje.
3. Brak gotowych skilli w `docs/skills/`.