### PR TITLE
Realizacja wytycznych dla issue i atomowych commitów

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,4 +6,5 @@
 2. Pracuj na osobnym branchu.
 3. Otwieraj Pull Request do głównego brancha projektu.
 4. Opisz zakres, weryfikację i ryzyka.
-5. Nie dodawaj sekretów ani danych produkcyjnych.
+5. Dziel zmiany na atomowe commity, gdy zakres obejmuje kilka niezależnych części.
+6. Nie dodawaj sekretów ani danych produkcyjnych.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,6 +11,13 @@ body:
     validations:
       required: true
   - type: textarea
+    id: impact
+    attributes:
+      label: Wpływ
+      description: Kogo dotyczy błąd i jak poważny jest skutek?
+    validations:
+      required: true
+  - type: textarea
     id: steps
     attributes:
       label: Kroki odtworzenia
@@ -39,7 +46,7 @@ body:
       label: Środowisko
       description: Wersja aplikacji, branch, commit, przeglądarka, system lub inne istotne dane.
     validations:
-      required: false
+      required: true
   - type: textarea
     id: logs
     attributes:
@@ -47,3 +54,16 @@ body:
       render: shell
     validations:
       required: false
+  - type: checkboxes
+    id: completeness
+    attributes:
+      label: Kontrola kompletności
+      options:
+        - label: Opis wskazuje faktyczne zachowanie i skutek.
+          required: true
+        - label: Kroki odtworzenia są możliwe do wykonania przez osobę trzecią.
+          required: true
+        - label: Oczekiwany i faktyczny wynik są rozdzielone.
+          required: true
+        - label: Podano środowisko albo wyjaśniono, dlaczego nie da się go ustalić.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: true
-contact_links:
-  - name: Pytanie lub dyskusja
-    url: https://github.com/OWNER/REPOSITORY/discussions
-    about: Użyj dyskusji, jeśli temat nie jest jeszcze konkretnym bugiem, featurem ani taskiem.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,6 +11,13 @@ body:
     validations:
       required: true
   - type: textarea
+    id: context
+    attributes:
+      label: Kontekst
+      description: Co obecnie nie działa, czego brakuje albo co ma zostać usprawnione?
+    validations:
+      required: true
+  - type: textarea
     id: scope
     attributes:
       label: Zakres
@@ -25,11 +32,25 @@ body:
         1. ...
         2. ...
     validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Poza zakresem
+      description: Czego to issue świadomie nie obejmuje?
+    validations:
       required: false
   - type: textarea
     id: acceptance
     attributes:
       label: Kryteria akceptacji
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Weryfikacja
+      description: Jak sprawdzić, że zmiana działa poprawnie?
     validations:
       required: false
   - type: textarea
@@ -38,3 +59,14 @@ body:
       label: Dodatkowe informacje
     validations:
       required: false
+  - type: checkboxes
+    id: completeness
+    attributes:
+      label: Kontrola kompletności
+      options:
+        - label: Cel opisuje problem, a nie tylko proponowane rozwiązanie.
+          required: true
+        - label: Zakres i przypadki użycia są wystarczające do przygotowania specyfikacji.
+          required: true
+        - label: Kryteria akceptacji są możliwe do zweryfikowania.
+          required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -26,8 +26,26 @@ body:
     validations:
       required: true
   - type: textarea
+    id: verification
+    attributes:
+      label: Weryfikacja
+      description: Jak sprawdzić wykonanie zadania?
+    validations:
+      required: true
+  - type: textarea
     id: risks
     attributes:
       label: Ryzyka lub zależności
     validations:
       required: false
+  - type: checkboxes
+    id: completeness
+    attributes:
+      label: Kontrola kompletności
+      options:
+        - label: Zakres prac jest rozbity na konkretne punkty.
+          required: true
+        - label: Warunek ukończenia jest jednoznaczny.
+          required: true
+        - label: Sposób weryfikacji jest opisany.
+          required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,9 @@ Ten plik definiuje podstawowe zasady dla agentów (AI i automatyzacji) pracując
 ### Issue (tworzenie i triage)
 
 - Przy zgłaszaniu bugów nie pomijam szczegółów z opisu (dokładne komendy/skrypty, pełny komunikat błędu).
+- Przy tworzeniu albo weryfikacji issue stosuj runbook `docs/runbooks/006-przygotowanie-issue-i-specyfikacji.md`.
+- Jeśli istniejące issue jest niekompletne, wypisz brakujące elementy w punktach zamiast zgadywać.
+- Issue powinno mieć cel, kontekst, zakres, kryteria akceptacji albo warunek ukończenia oraz sposób weryfikacji odpowiedni do typu zgłoszenia.
 
 ### PR i branchowanie (Git Flow)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,5 +117,9 @@ Ten plik definiuje podstawowe zasady dla agentów (AI i automatyzacji) pracując
 - Poza sytuacjami wyjątkowymi nie robię commitów bezpośrednio do `main`.
   - jeśli człowiek prosi o commit/push do `main`, traktuję to jako nadpisanie tej zasady (patrz zasada `Nadpisywanie wytycznych`)
 - Każdy commit przygotowuję jako możliwie mały i atomowy; zasada dotyczy także commitów inicjowanych skrótami (`c`, `c+p`, `c+p+pr`).
+- Przy commitowaniu stosuj runbook `docs/runbooks/007-atomowe-commity.md`.
+- Jeśli zakres pracy naturalnie dzieli się na niezależne części, przygotuj kilka commitów zamiast jednego zbiorczego.
+- Nie mieszaj w jednym commicie niepowiązanych zmian, np. poprawki błędu, refaktoru, dokumentacji i konfiguracji.
+- Jeden push może zawierać serię atomowych commitów.
 - Każdy commit ma nazwę i krótki opis zmian.
 - Opis commita zawiera informację, na podstawie jakiej specyfikacji wykonano pracę (plik/spec lub issue) i zawiera do niej odniesienie.

--- a/docs/runbooks/006-przygotowanie-issue-i-specyfikacji.md
+++ b/docs/runbooks/006-przygotowanie-issue-i-specyfikacji.md
@@ -1,0 +1,105 @@
+# Runbook: przygotowanie issue i wstępnej specyfikacji
+
+## Cel
+
+Przygotować issue tak, aby człowiek albo agent mógł na jego podstawie wykonać triage, przygotować specyfikację i rozpocząć pracę bez zgadywania intencji.
+
+## Kiedy używać
+
+1. Gdy tworzysz nowe issue.
+2. Gdy sprawdzasz, czy istniejące issue jest gotowe do realizacji.
+3. Gdy issue ma być podstawą do przygotowania specyfikacji.
+
+## Zasady ogólne
+
+1. Issue ma opisywać problem i oczekiwany efekt, nie tylko preferowaną implementację.
+2. Brakujące dane wypisz w punktach jako listę braków.
+3. Nie uzupełniaj niepewnych informacji własnymi założeniami, jeśli mogą zmienić zakres pracy.
+4. Jeżeli decyzja człowieka jest konieczna, zadaj jedno konkretne pytanie naraz.
+5. Jeżeli issue jest wystarczające do pracy, napisz to wprost i wskaż minimalny kolejny krok.
+
+## Issue typu Bug
+
+Issue typu Bug powinno zawierać:
+
+1. Opis faktycznego problemu.
+2. Wpływ na użytkownika, dane, proces albo system.
+3. Kroki odtworzenia.
+4. Oczekiwany wynik.
+5. Faktyczny wynik.
+6. Środowisko, wersję, branch, commit albo inny punkt odniesienia.
+7. Logi, komunikaty błędów, screenshoty albo linki do monitoringu, jeśli istnieją.
+
+## Issue typu Feature
+
+Issue typu Feature powinno zawierać:
+
+1. Cel biznesowy albo użytkowy.
+2. Kontekst obecnego ograniczenia.
+3. Zakres oczekiwanej zmiany.
+4. Przypadki użycia.
+5. Kryteria akceptacji.
+6. Wstępny sposób weryfikacji.
+7. Elementy poza zakresem, jeśli mogłyby być mylące.
+
+## Issue typu Task
+
+Issue typu Task powinno zawierać:
+
+1. Kontekst zadania.
+2. Zakres prac.
+3. Warunek ukończenia.
+4. Sposób weryfikacji.
+5. Ryzyka albo zależności, jeśli występują.
+
+## Wstępna specyfikacja dla issue
+
+Jeżeli issue wymaga specyfikacji, przygotuj ją tak, aby obejmowała:
+
+1. Cel.
+2. Zakres.
+3. Przypadki użycia.
+4. Wymagania funkcjonalne.
+5. Przypadki brzegowe.
+6. Wpływ na istniejący system.
+7. Kryteria akceptacji.
+8. Plan walidacji.
+9. Ryzyka i rollback.
+
+Jeżeli projekt nie ma własnej decyzji o miejscu specyfikacji, użyj `docs/specs/` i szablonu `docs/specs/_template.md`.
+
+## Weryfikacja istniejącego issue
+
+1. Ustal typ issue:
+   a) Bug
+   b) Feature
+   c) Task
+2. Porównaj treść issue z checklistą dla danego typu.
+3. Wypisz braki jako listę punktów.
+4. Oznacz elementy blokujące realizację.
+5. Jeżeli brakuje tylko drobnych danych, wskaż je jako uzupełnienie, ale nie blokuj pracy bez powodu.
+
+## Format odpowiedzi przy brakach
+
+```md
+Issue nie jest jeszcze kompletne do realizacji.
+
+Brakuje:
+1. ...
+2. ...
+
+Blokujące:
+1. ...
+
+Pytanie:
+1. ...
+```
+
+## Format odpowiedzi przy komplecie
+
+```md
+Issue jest kompletne do dalszej pracy.
+
+Następny krok:
+1. Przygotować specyfikację w `docs/specs/` albo rozpocząć implementację, jeśli proces projektu na to pozwala.
+```

--- a/docs/runbooks/007-atomowe-commity.md
+++ b/docs/runbooks/007-atomowe-commity.md
@@ -1,0 +1,110 @@
+# Runbook: atomowe commity
+
+## Cel
+
+Dzielić zmiany na małe, logicznie spójne commity, które ułatwiają review, rollback i analizę historii.
+
+## Kiedy używać
+
+1. Przy każdym poleceniu `c`, `c+p` albo `c+p+pr`.
+2. Przy kończeniu zadania obejmującego więcej niż jeden typ zmiany.
+3. Przed wypchnięciem brancha z większym zakresem prac.
+
+## Zasady
+
+1. Jeden commit powinien zawierać jedną logiczną zmianę.
+2. Nie mieszaj w jednym commicie niepowiązanych obszarów.
+3. Jeżeli zmiana dokumentacji opisuje dokładnie tę samą zmianę kodu, może być w tym samym commicie.
+4. Jeżeli dokumentacja, konfiguracja albo testy dotyczą niezależnego tematu, zrób osobny commit.
+5. Jeden push może zawierać serię kilku atomowych commitów.
+6. Nie twórz sztucznie małych commitów, które osobno nie mają sensu.
+
+## Typowe granice commitów
+
+1. Zmiana funkcjonalna.
+2. Testy dla tej zmiany.
+3. Migracja lub zmiana schematu danych.
+4. Dokumentacja procesu albo runbook.
+5. Konfiguracja narzędzi.
+6. Refaktor bez zmiany zachowania.
+7. Poprawka po review.
+
+## Procedura
+
+1. Sprawdź stan repo:
+
+```sh
+git status --short
+```
+
+2. Zobacz pełny zakres zmian:
+
+```sh
+git diff
+git diff --stat
+```
+
+3. Podziel zmiany na logiczne grupy.
+4. Dla każdej grupy zdecyduj:
+   a) jaki problem rozwiązuje
+   b) jakie pliki do niej należą
+   c) czy commit będzie samodzielnie zrozumiały
+5. Dodawaj pliki albo hunki selektywnie:
+
+```sh
+git add <plik>
+git add -p <plik>
+```
+
+6. Przed każdym commitem sprawdź staged diff:
+
+```sh
+git diff --cached --stat
+git diff --cached
+```
+
+7. Utwórz commit z nazwą i krótkim opisem:
+
+```sh
+git commit -m "Krótka nazwa zmiany" -m "Opis zakresu i powodu zmiany." -m "Specyfikacja: <plik albo issue>."
+```
+
+8. Powtarzaj kroki dla kolejnych grup.
+9. Po ostatnim commicie sprawdź historię:
+
+```sh
+git log --oneline --decorate -5
+git status --short
+```
+
+10. Wypchnij serię commitów jednym pushem, jeśli człowiek o to poprosił:
+
+```sh
+git push
+```
+
+## Weryfikacja
+
+1. Każdy commit ma jeden temat.
+2. Żaden commit nie miesza niepowiązanych zmian.
+3. Nazwa i opis commita odpowiadają rzeczywistej zawartości.
+4. Seria commitów odtwarza tok pracy w kolejności logicznej.
+5. Working tree po commitach nie zawiera przypadkowych zmian.
+
+## Przykłady
+
+### Dobrze
+
+1. `Dodaj szablony issue`
+2. `Opisz procedurę przygotowania issue`
+3. `Dodaj runbook atomowych commitów`
+
+### Źle
+
+1. `Zmiany`
+2. `Update`
+3. Jeden commit zawierający równocześnie:
+   a) refaktor kodu
+   b) poprawkę buga
+   c) nowy runbook
+   d) zmianę konfiguracji CI

--- a/docs/runbooks/AGENTS.md
+++ b/docs/runbooks/AGENTS.md
@@ -22,6 +22,8 @@ Ten plik jest mapą instrukcji operacyjnych (runbooków) dla agenta.
   - Ogólna checklista release/deploy.
 - `docs/runbooks/005-diagnostyka-ci.md`
   - Ogólna procedura diagnostyki błędów CI.
+- `docs/runbooks/006-przygotowanie-issue-i-specyfikacji.md`
+  - Ogólna procedura przygotowania i weryfikacji issue oraz wstępnej specyfikacji.
 - `docs/runbooks/*.md`
   - Poszczególne runbooki (jeden plik na jeden proces/obszar).
 

--- a/docs/runbooks/AGENTS.md
+++ b/docs/runbooks/AGENTS.md
@@ -24,6 +24,8 @@ Ten plik jest mapą instrukcji operacyjnych (runbooków) dla agenta.
   - Ogólna procedura diagnostyki błędów CI.
 - `docs/runbooks/006-przygotowanie-issue-i-specyfikacji.md`
   - Ogólna procedura przygotowania i weryfikacji issue oraz wstępnej specyfikacji.
+- `docs/runbooks/007-atomowe-commity.md`
+  - Ogólna procedura dzielenia zmian na atomowe, logiczne commity.
 - `docs/runbooks/*.md`
   - Poszczególne runbooki (jeden plik na jeden proces/obszar).
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -11,6 +11,7 @@ Katalog zawiera runbooki, czyli powtarzalne instrukcje operacyjne dla agenta.
 - `004-release-deploy-checklista.md` - ogólna checklista release/deploy.
 - `005-diagnostyka-ci.md` - ogólna diagnostyka CI.
 - `006-przygotowanie-issue-i-specyfikacji.md` - ogólne przygotowanie i weryfikacja issue oraz wstępnej specyfikacji.
+- `007-atomowe-commity.md` - ogólne dzielenie zmian na atomowe, logiczne commity.
 - `*.md` - runbooki dla konkretnych procesów.
 
 ## Jak używać

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -10,6 +10,7 @@ Katalog zawiera runbooki, czyli powtarzalne instrukcje operacyjne dla agenta.
 - `003-obsluga-issue-api.md` - ogólna obsługa issue przez API.
 - `004-release-deploy-checklista.md` - ogólna checklista release/deploy.
 - `005-diagnostyka-ci.md` - ogólna diagnostyka CI.
+- `006-przygotowanie-issue-i-specyfikacji.md` - ogólne przygotowanie i weryfikacja issue oraz wstępnej specyfikacji.
 - `*.md` - runbooki dla konkretnych procesów.
 
 ## Jak używać


### PR DESCRIPTION
## Cel

Realizacja otwartych issue dotyczących przygotowania issue/specyfikacji oraz atomowych commitów.

Closes #1
Closes #2
Closes #12

## Zakres

1. Rozszerzono szablony issue o brakujące pola i checklisty kompletności.
2. Dodano runbook `docs/runbooks/006-przygotowanie-issue-i-specyfikacji.md` opisujący tworzenie i weryfikację issue oraz wstępną specyfikację.
3. Dopisano w `AGENTS.md` zasady sprawdzania kompletności issue.
4. Dodano runbook `docs/runbooks/007-atomowe-commity.md` z procedurą dzielenia zmian na logiczne commity.
5. Doprecyzowano zasady atomowych commitów w `AGENTS.md` i `.github/CONTRIBUTING.md`.

## Weryfikacja

1. Parsowanie YAML przez Ruby `YAML.load_file` dla plików `.github`.
2. `git diff --stat origin/main..HEAD`.
3. Sprawdzenie historii: zmiany są rozbite na 2 logiczne commity.