### PR TITLE
Linkowanie ścieżek w README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Ten plik definiuje podstawowe zasady dla agentów (AI i automatyzacji) pracując
 - W każdym folderze projektu powinien istnieć plik `README.md` opisujący zawartość folderu oraz informacje o podkatalogach.
 - Pliki `AGENTS.md` są przeznaczone dla agentów i automatyzacji.
 - Pliki `README.md` są przeznaczone dla człowieka.
+- W plikach `README.md` linkuj lokalne pliki i katalogi zwykłymi linkami Markdown, gdy tylko realnie ułatwia to człowiekowi nawigację po repozytorium.
 - Nie duplikuj semantycznie tych samych zasad w `AGENTS.md` i `README.md`; jeśli trzeba coś doprecyzować, ujednolić istniejący wpis zamiast dopisywać równoległy.
 - Dodawaj krótkie komentarze tylko tam, gdzie logika nie jest oczywista.
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Repozytorium startowe dla projektów, w których człowiek i agenci AI mają pra
 
 ## Zawartość
 
-- `AGENTS.md` - zasady pracy dla agentów i automatyzacji.
-- `.github/` - szablony GitHuba, Pull Requestów, issue, instrukcje Copilota i pliki community health.
-- `docs/` - dokumentacja operacyjna i techniczna projektu.
-- `docs/apis/` - dokumentacja integracji API.
-- `docs/specs/` - specyfikacje zmian i funkcjonalności.
-- `docs/runbooks/` - syntetyczne procedury operacyjne.
-- `docs/skills/` - puste miejsce na przyszłe skille agenta.
-- `scripts/` - helpery do pracy z API i środowiskiem.
+- [`AGENTS.md`](AGENTS.md) - zasady pracy dla agentów i automatyzacji.
+- [`.github/`](.github/) - szablony GitHuba, Pull Requestów, issue, instrukcje Copilota i pliki community health.
+- [`docs/`](docs/) - dokumentacja operacyjna i techniczna projektu.
+- [`docs/apis/`](docs/apis/) - dokumentacja integracji API.
+- [`docs/specs/`](docs/specs/) - specyfikacje zmian i funkcjonalności.
+- [`docs/runbooks/`](docs/runbooks/) - syntetyczne procedury operacyjne.
+- [`docs/skills/`](docs/skills/) - puste miejsce na przyszłe skille agenta.
+- [`scripts/`](scripts/) - helpery do pracy z API i środowiskiem.
 
 ## Szybki start
 
@@ -39,33 +39,33 @@ Alternatywnie możesz użyć GitHuba i opcji "Use this template", jeśli tworzys
 
 Podczas adaptacji nie chodzi o mechaniczne skopiowanie wszystkich plików. Celem jest dopasowanie zasad pracy agentowej do konkretnego projektu.
 
-1. `AGENTS.md`
+1. [`AGENTS.md`](AGENTS.md)
    a) zostaw tylko zasady, które mają obowiązywać w projekcie
    b) dopisz język komunikacji, git flow, zasady commitów, proces specyfikacji i ograniczenia środowiskowe
    c) przenieś zasady lokalne do najbliższego folderu, którego dotyczą
-   d) unikaj duplikatów semantycznych między głównym `AGENTS.md` i plikami podrzędnymi
-2. `.github/`
+   d) unikaj duplikatów semantycznych między głównym [`AGENTS.md`](AGENTS.md) i plikami podrzędnymi
+2. [`.github/`](.github/)
    a) dopasuj szablony issue do realnego procesu triage
    b) dopasuj Pull Request template do wymaganej weryfikacji
    c) uzupełnij instrukcje Copilota o technologie, wersje środowiska i zasady code review
-   d) usuń `CODEOWNERS`, `SECURITY.md`, `SUPPORT.md`, Dependabot albo inne pliki, jeśli projekt nie ma dla nich realnej treści
-3. `docs/specs/`
+   d) usuń [`.github/CODEOWNERS`](.github/CODEOWNERS), [`.github/SECURITY.md`](.github/SECURITY.md), [`.github/SUPPORT.md`](.github/SUPPORT.md), Dependabot albo inne pliki, jeśli projekt nie ma dla nich realnej treści
+3. [`docs/specs/`](docs/specs/)
    a) zostaw, jeśli projekt wymaga specyfikacji przed implementacją
    b) ustal schemat numeracji i kryteria akceptacji
    c) usuń katalog, jeśli projekt prowadzi specyfikacje wyłącznie w issue
-4. `docs/runbooks/`
+4. [`docs/runbooks/`](docs/runbooks/)
    a) dopisuj tylko powtarzalne procedury, które naprawdę będą używane
    b) usuwaj runbooki generyczne, jeśli nie pasują do procesu projektu
-5. `docs/apis/`
+5. [`docs/apis/`](docs/apis/)
    a) zostaw dokumentację tylko tych integracji, których projekt używa
    b) usuń GitHub albo Forgejo, jeśli nie są potrzebne
-6. `docs/skills/`
+6. [`docs/skills/`](docs/skills/)
    a) zostaw puste, dopóki projekt nie potrzebuje własnych skilli agenta
    b) dodawaj skille dopiero dla powtarzalnych workflow
-7. `scripts/`
+7. [`scripts/`](scripts/)
    a) zostaw helpery, które będą realnie używane
    b) usuń skrypty związane z niewykorzystywanymi integracjami
-8. `.env.example`
+8. [`.env.example`](.env.example)
    a) uzupełnij tylko zmienne konfiguracyjne bez sekretów
    b) usuń zmienne dla nieużywanych integracji
 
@@ -86,4 +86,4 @@ Jeśli projekt nie jest aplikacją, opisz główny sposób użycia repozytorium,
 
 ## Licencja
 
-MIT. Szczegóły w pliku `LICENSE`.
+MIT. Szczegóły w pliku [`LICENSE`](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,21 +4,21 @@ Ten folder zawiera uporządkowaną dokumentację i wiedzę o repozytorium.
 
 ## Spis treści
 
-- `apis/`
+- [`apis/`](apis/)
   - dokumentacja integracji API (konfiguracja, endpointy, operacje)
-- `followups.md`
+- [`followups.md`](followups.md)
   - rejestr cyklicznych lub odłożonych kontroli
-- `system-map.md`
+- [`system-map.md`](system-map.md)
   - mapa komponentów, środowisk i zależności projektu
-- `integrations.md`
+- [`integrations.md`](integrations.md)
   - indeks integracji zewnętrznych
-- `cron.md`
+- [`cron.md`](cron.md)
   - mapa zadań cyklicznych, jeśli projekt ich używa
-- `specs/`
+- [`specs/`](specs/)
   - specyfikacje zmian (gdy nie są prowadzone jako komentarz do issue na Forgejo)
-- `runbooks/`
+- [`runbooks/`](runbooks/)
   - instrukcje operacyjne dla agenta (jak wykonywać powtarzalne czynności)
-- `skills/`
+- [`skills/`](skills/)
   - miejsce na przyszłe skille agenta AI
-- `optimizations/`
+- [`optimizations/`](optimizations/)
   - miejsce na notatki i runbooki dotyczące optymalizacji

--- a/docs/apis/README.md
+++ b/docs/apis/README.md
@@ -4,13 +4,13 @@ Katalog zawiera dokumentację integracji API używanych w projekcie.
 
 ## Zawartość
 
-- `AGENTS.md` - zasady prowadzenia dokumentacji API i mapa plików.
-- `Forgejo-API.md` - dokumentacja operacyjna integracji z Forgejo API.
-- `GitHub-API.md` - dokumentacja operacyjna integracji z GitHub API.
+- [`AGENTS.md`](AGENTS.md) - zasady prowadzenia dokumentacji API i mapa plików.
+- [`Forgejo-API.md`](Forgejo-API.md) - dokumentacja operacyjna integracji z Forgejo API.
+- [`GitHub-API.md`](GitHub-API.md) - dokumentacja operacyjna integracji z GitHub API.
 - `*.md` - kolejne dokumenty integracji API.
 
 ## Jak używać
 
-1. Sprawdź zasady i mapę plików w `AGENTS.md`.
+1. Sprawdź zasady i mapę plików w [`AGENTS.md`](AGENTS.md).
 2. Dodaj nową integrację API jako osobny plik `*.md`.
-3. Uzupełnij mapę plików w `AGENTS.md`.
+3. Uzupełnij mapę plików w [`AGENTS.md`](AGENTS.md).

--- a/docs/optimizations/README.md
+++ b/docs/optimizations/README.md
@@ -4,6 +4,6 @@ Katalog zawiera dokumentację dotyczącą optymalizacji.
 
 ## Zawartość
 
-- `AGENTS.md` - zasady dla agentów.
-- `szablon-optymalizacji.md` - wzór notatki optymalizacyjnej.
-- `pomysly.md` - lista pomysłów do późniejszego triage.
+- [`AGENTS.md`](AGENTS.md) - zasady dla agentów.
+- [`szablon-optymalizacji.md`](szablon-optymalizacji.md) - wzór notatki optymalizacyjnej.
+- [`pomysly.md`](pomysly.md) - lista pomysłów do późniejszego triage.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -4,18 +4,18 @@ Katalog zawiera runbooki, czyli powtarzalne instrukcje operacyjne dla agenta.
 
 ## Zawartość
 
-- `AGENTS.md` - zasady tworzenia i mapa runbooków.
-- `001-pr-review.md` - ogólny przegląd Pull Requesta.
-- `002-smoke-test-po-zmianach.md` - ogólny smoke test po zmianach.
-- `003-obsluga-issue-api.md` - ogólna obsługa issue przez API.
-- `004-release-deploy-checklista.md` - ogólna checklista release/deploy.
-- `005-diagnostyka-ci.md` - ogólna diagnostyka CI.
-- `006-przygotowanie-issue-i-specyfikacji.md` - ogólne przygotowanie i weryfikacja issue oraz wstępnej specyfikacji.
-- `007-atomowe-commity.md` - ogólne dzielenie zmian na atomowe, logiczne commity.
+- [`AGENTS.md`](AGENTS.md) - zasady tworzenia i mapa runbooków.
+- [`001-pr-review.md`](001-pr-review.md) - ogólny przegląd Pull Requesta.
+- [`002-smoke-test-po-zmianach.md`](002-smoke-test-po-zmianach.md) - ogólny smoke test po zmianach.
+- [`003-obsluga-issue-api.md`](003-obsluga-issue-api.md) - ogólna obsługa issue przez API.
+- [`004-release-deploy-checklista.md`](004-release-deploy-checklista.md) - ogólna checklista release/deploy.
+- [`005-diagnostyka-ci.md`](005-diagnostyka-ci.md) - ogólna diagnostyka CI.
+- [`006-przygotowanie-issue-i-specyfikacji.md`](006-przygotowanie-issue-i-specyfikacji.md) - ogólne przygotowanie i weryfikacja issue oraz wstępnej specyfikacji.
+- [`007-atomowe-commity.md`](007-atomowe-commity.md) - ogólne dzielenie zmian na atomowe, logiczne commity.
 - `*.md` - runbooki dla konkretnych procesów.
 
 ## Jak używać
 
-1. Sprawdź zasady w `AGENTS.md`.
+1. Sprawdź zasady w [`AGENTS.md`](AGENTS.md).
 2. Dodaj nowy runbook jako osobny plik `*.md`.
-3. Uzupełnij mapę plików w `AGENTS.md`.
+3. Uzupełnij mapę plików w [`AGENTS.md`](AGENTS.md).

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -4,7 +4,7 @@ Katalog jest pustym miejscem na przyszłe skille agenta AI.
 
 ## Zawartość
 
-- `AGENTS.md` - zasady dla agentów dotyczące tego katalogu.
+- [`AGENTS.md`](AGENTS.md) - zasady dla agentów dotyczące tego katalogu.
 
 ## Kiedy dodawać skill
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -4,12 +4,12 @@ Katalog zawiera specyfikacje funkcjonalności przygotowywane pod implementację.
 
 ## Zawartość
 
-- `AGENTS.md` - zasady tworzenia i mapa plików specyfikacji.
-- `_template.md` - bazowy szablon specyfikacji.
+- [`AGENTS.md`](AGENTS.md) - zasady tworzenia i mapa plików specyfikacji.
+- [`_template.md`](_template.md) - bazowy szablon specyfikacji.
 - `*.md` - specyfikacje funkcjonalności (po jednej funkcjonalności na plik).
 
 ## Jak używać
 
-1. Sprawdź zasady w `AGENTS.md`.
-2. Skopiuj strukturę z `_template.md`.
-3. Uzupełnij mapę plików w `AGENTS.md`.
+1. Sprawdź zasady w [`AGENTS.md`](AGENTS.md).
+2. Skopiuj strukturę z [`_template.md`](_template.md).
+3. Uzupełnij mapę plików w [`AGENTS.md`](AGENTS.md).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,11 +4,11 @@ Katalog zawiera skrypty pomocnicze do pracy z repozytorium i integracjami.
 
 ## Zawartość
 
-- `forgejo-issues.sh` - operacje na issue przez API Forgejo (odczyt, tworzenie, komentarze, zmiana stanu).
-- `github-issues.sh` - operacje na issue przez API GitHub (odczyt, tworzenie, komentarze, zmiana stanu).
-- `load_env.sh` - bezpieczne ładowanie wybranych kluczy z `.env` bez wypisywania sekretów.
+- [`forgejo-issues.sh`](forgejo-issues.sh) - operacje na issue przez API Forgejo (odczyt, tworzenie, komentarze, zmiana stanu).
+- [`github-issues.sh`](github-issues.sh) - operacje na issue przez API GitHub (odczyt, tworzenie, komentarze, zmiana stanu).
+- [`load_env.sh`](load_env.sh) - bezpieczne ładowanie wybranych kluczy z `.env` bez wypisywania sekretów.
 
 ## Uruchamianie
 
 Skrypty uruchamiaj z poziomu repo po ustawieniu wymaganych zmiennych środowiskowych.
-Szczegóły konfiguracji są opisane w dokumentacji technicznej katalogu `docs/`.
+Szczegóły konfiguracji są opisane w dokumentacji technicznej katalogu [`docs/`](../docs/).


### PR DESCRIPTION
## Cel

Ułatwienie człowiekowi nawigacji po dokumentacji przez linkowanie lokalnych plików i katalogów bezpośrednio w plikach README.

## Zakres

1. Dodano zasadę linkowania lokalnych plików i katalogów w `AGENTS.md`.
2. Podlinkowano lokalne ścieżki we wszystkich plikach `README.md` w repozytorium.

## Weryfikacja

1. Skrypt Ruby sprawdził, że wszystkie lokalne linki Markdown z README wskazują istniejące pliki albo katalogi.
2. Sprawdzono diff i listę zmienionych plików.